### PR TITLE
Add: Logging strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Initial release
 - Add Caching strategies;
+- Add Logging strategies;

--- a/lib/f_http_client.rb
+++ b/lib/f_http_client.rb
@@ -11,6 +11,10 @@ require 'f_http_client/cache/key'
 require 'f_http_client/cache/null'
 require 'f_http_client/cache/rails'
 
+require 'f_http_client/logger/default'
+require 'f_http_client/logger/null'
+require 'f_http_client/logger/rails'
+
 module FHTTPClient
   class Error < StandardError; end
   # Your code goes here...

--- a/lib/f_http_client/logger/default.rb
+++ b/lib/f_http_client/logger/default.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module FHTTPClient
+  module Logger
+    # A Basic logger to use when no logger is provided
+    class Default
+      def initialize(tags: [])
+        @logger = ::Logger.new($stdout)
+        @current_tags = tags
+      end
+
+      def tagged(*tags)
+        tagged = self.class.new(tags: current_tags + tags)
+        block_given? ? yield(tagged) : tagged
+      end
+
+      def debug(message) = add(::Logger::DEBUG, message)
+      def info(message) = add(::Logger::INFO, message)
+      def warn(message) = add(::Logger::WARN, message)
+      def error(message) = add(::Logger::ERROR, message)
+      def fatal(message) = add(::Logger::FATAL, message)
+      def unknown(message) = add(::Logger::UNKNOWN, message)
+
+      private
+
+      attr_reader :logger, :current_tags
+
+      def add(severity, message)
+        formatted_tags = format_tags
+        full_message = formatted_tags.empty? ? message : [format_tags, message].join(' - ')
+
+        logger.add(severity, full_message)
+      end
+
+      def format_tags
+        current_tags.map { |tag| "[#{tag}]" }.join(' ')
+      end
+    end
+  end
+end

--- a/lib/f_http_client/logger/null.rb
+++ b/lib/f_http_client/logger/null.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module FHTTPClient
+  module Logger
+    # Logs nothing
+    class Null
+      def tagged(...) = block_given? ? yield(self) : self
+      def debug(...) = nil
+      def info(...) = nil
+      def warn(...) = nil
+      def error(...) = nil
+      def fatal(...) = nil
+      def unknown(...) = nil
+    end
+  end
+end

--- a/lib/f_http_client/logger/rails.rb
+++ b/lib/f_http_client/logger/rails.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module FHTTPClient
+  module Logger
+    # Logging with Rails logger
+    class Rails
+      extend Forwardable
+
+      delegate %i[tagged debug info warn error fatal unknown] => :@logger
+
+      def initialize
+        @logger = ::Rails.logger
+      end
+    end
+  end
+end

--- a/spec/f_http_client/logger/default_spec.rb
+++ b/spec/f_http_client/logger/default_spec.rb
@@ -1,0 +1,285 @@
+# frozen_string_literal: true
+
+RSpec.describe FHTTPClient::Logger::Default do
+  describe '#initialize' do
+    context 'when no args are given' do
+      it { expect(described_class.new).to be_an_instance_of(described_class) }
+    end
+
+    context 'when tags are given' do
+      it { expect(described_class.new(tags: ['FHTTPClient'])).to be_an_instance_of(described_class) }
+    end
+  end
+
+  describe '#tagged' do
+    subject(:logger) { described_class.new }
+
+    context 'when no args are given' do
+      context 'and no block is given' do
+        it { expect(logger.tagged).to be_an_instance_of(described_class) }
+      end
+
+      context 'and block is given' do
+        it { expect { |block| logger.tagged(&block) }.to yield_with_args(an_instance_of(described_class)) }
+      end
+    end
+
+    context 'and args are given' do
+      context 'and no block is given' do
+        it { expect(logger.tagged('FHTTPClient')).to be_an_instance_of(described_class) }
+      end
+
+      context 'and block is given' do
+        it do
+          expect { |block| logger.tagged('FHTTPClient', &block) }.to yield_with_args(an_instance_of(described_class))
+        end
+      end
+    end
+  end
+
+  describe '#debug' do
+    subject(:logger) { described_class.new }
+
+    let(:logging) { instance_double(Logger) }
+
+    before do
+      allow(Logger).to receive(:new).and_return(logging)
+      allow(logging).to receive(:add)
+    end
+
+    context 'when no tags are given' do
+      it 'logs without tags' do
+        logger.debug('Something happened.')
+        expect(logging).to have_received(:add).with(Logger::DEBUG, 'Something happened.')
+      end
+    end
+
+    context 'when tags are given' do
+      context 'and tag are set before logging' do
+        it 'logs with tags' do
+          tagged_log = logger.tagged('Inspect', 'Error')
+          tagged_log.debug('Something happened.')
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::DEBUG, '[Inspect] [Error] - Something happened.')
+        end
+      end
+
+      context 'and tag are given in a block' do
+        it 'logs with tags' do
+          logger.tagged('Inspect', 'Error') { |tagged_log| tagged_log.debug('Something happened.') }
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::DEBUG, '[Inspect] [Error] - Something happened.')
+        end
+      end
+    end
+  end
+
+  describe '#info' do
+    subject(:logger) { described_class.new }
+
+    let(:logging) { instance_double(Logger) }
+
+    before do
+      allow(Logger).to receive(:new).and_return(logging)
+      allow(logging).to receive(:add)
+    end
+
+    context 'when no tags are given' do
+      it 'logs without tags' do
+        logger.info('Something happened.')
+        expect(logging).to have_received(:add).with(Logger::INFO, 'Something happened.')
+      end
+    end
+
+    context 'when tags are given' do
+      context 'and tag are set before logging' do
+        it 'logs with tags' do
+          tagged_log = logger.tagged('Inspect', 'Error')
+          tagged_log.info('Something happened.')
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::INFO, '[Inspect] [Error] - Something happened.')
+        end
+      end
+
+      context 'and tag are given in a block' do
+        it 'logs with tags' do
+          logger.tagged('Inspect', 'Error') { |tagged_log| tagged_log.info('Something happened.') }
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::INFO, '[Inspect] [Error] - Something happened.')
+        end
+      end
+    end
+  end
+
+  describe '#warn' do
+    subject(:logger) { described_class.new }
+
+    let(:logging) { instance_double(Logger) }
+
+    before do
+      allow(Logger).to receive(:new).and_return(logging)
+      allow(logging).to receive(:add)
+    end
+
+    context 'when no tags are given' do
+      it 'logs without tags' do
+        logger.warn('Something happened.')
+        expect(logging).to have_received(:add).with(Logger::WARN, 'Something happened.')
+      end
+    end
+
+    context 'when tags are given' do
+      context 'and tag are set before logging' do
+        it 'logs with tags' do
+          tagged_log = logger.tagged('Inspect', 'Error')
+          tagged_log.warn('Something happened.')
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::WARN, '[Inspect] [Error] - Something happened.')
+        end
+      end
+
+      context 'and tag are given in a block' do
+        it 'logs with tags' do
+          logger.tagged('Inspect', 'Error') { |tagged_log| tagged_log.warn('Something happened.') }
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::WARN, '[Inspect] [Error] - Something happened.')
+        end
+      end
+    end
+  end
+
+  describe '#error' do
+    subject(:logger) { described_class.new }
+
+    let(:logging) { instance_double(Logger) }
+
+    before do
+      allow(Logger).to receive(:new).and_return(logging)
+      allow(logging).to receive(:add)
+    end
+
+    context 'when no tags are given' do
+      it 'logs without tags' do
+        logger.error('Something happened.')
+        expect(logging).to have_received(:add).with(Logger::ERROR, 'Something happened.')
+      end
+    end
+
+    context 'when tags are given' do
+      context 'and tag are set before logging' do
+        it 'logs with tags' do
+          tagged_log = logger.tagged('Inspect', 'Error')
+          tagged_log.error('Something happened.')
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::ERROR, '[Inspect] [Error] - Something happened.')
+        end
+      end
+
+      context 'and tag are given in a block' do
+        it 'logs with tags' do
+          logger.tagged('Inspect', 'Error') { |tagged_log| tagged_log.error('Something happened.') }
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::ERROR, '[Inspect] [Error] - Something happened.')
+        end
+      end
+    end
+  end
+
+  describe '#fatal' do
+    subject(:logger) { described_class.new }
+
+    let(:logging) { instance_double(Logger) }
+
+    before do
+      allow(Logger).to receive(:new).and_return(logging)
+      allow(logging).to receive(:add)
+    end
+
+    context 'when no tags are given' do
+      it 'logs without tags' do
+        logger.fatal('Something happened.')
+        expect(logging).to have_received(:add).with(Logger::FATAL, 'Something happened.')
+      end
+    end
+
+    context 'when tags are given' do
+      context 'and tag are set before logging' do
+        it 'logs with tags' do
+          tagged_log = logger.tagged('Inspect', 'fatal')
+          tagged_log.fatal('Something happened.')
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::FATAL, '[Inspect] [fatal] - Something happened.')
+        end
+      end
+
+      context 'and tag are given in a block' do
+        it 'logs with tags' do
+          logger.tagged('Inspect', 'fatal') { |tagged_log| tagged_log.fatal('Something happened.') }
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::FATAL, '[Inspect] [fatal] - Something happened.')
+        end
+      end
+    end
+  end
+
+  describe '#unknown' do
+    subject(:logger) { described_class.new }
+
+    let(:logging) { instance_double(Logger) }
+
+    before do
+      allow(Logger).to receive(:new).and_return(logging)
+      allow(logging).to receive(:add)
+    end
+
+    context 'when no tags are given' do
+      it 'logs without tags' do
+        logger.unknown('Something happened.')
+        expect(logging).to have_received(:add).with(Logger::UNKNOWN, 'Something happened.')
+      end
+    end
+
+    context 'when tags are given' do
+      context 'and tag are set before logging' do
+        it 'logs with tags' do
+          tagged_log = logger.tagged('Inspect', 'unknown')
+          tagged_log.unknown('Something happened.')
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::UNKNOWN, '[Inspect] [unknown] - Something happened.')
+        end
+      end
+
+      context 'and tag are given in a block' do
+        it 'logs with tags' do
+          logger.tagged('Inspect', 'unknown') { |tagged_log| tagged_log.unknown('Something happened.') }
+
+          expect(logging)
+            .to have_received(:add)
+            .with(Logger::UNKNOWN, '[Inspect] [unknown] - Something happened.')
+        end
+      end
+    end
+  end
+end

--- a/spec/f_http_client/logger/null_spec.rb
+++ b/spec/f_http_client/logger/null_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe FHTTPClient::Logger::Null do
+  describe '#tagged' do
+    subject(:logger) { described_class.new }
+
+    context 'when no args are given' do
+      context 'and no block is given' do
+        it { expect(logger.tagged).to be_an_instance_of(described_class) }
+      end
+
+      context 'and block is given' do
+        it { expect { |block| logger.tagged(&block) }.to yield_with_args(an_instance_of(described_class)) }
+      end
+    end
+
+    context 'and args are given' do
+      context 'and no block is given' do
+        it { expect(logger.tagged('FHTTPCLient')).to be_an_instance_of(described_class) }
+      end
+
+      context 'and block is given' do
+        it do
+          expect { |block| logger.tagged('FHTTPCLient', &block) }.to yield_with_args(an_instance_of(described_class))
+        end
+      end
+    end
+  end
+
+  describe '#debug' do
+    subject(:logger) { described_class.new }
+
+    it { expect(logger).to respond_to(:debug) }
+  end
+
+  describe '#info' do
+    subject(:logger) { described_class.new }
+
+    it { expect(logger).to respond_to(:info) }
+  end
+
+  describe '#warn' do
+    subject(:logger) { described_class.new }
+
+    it { expect(logger).to respond_to(:warn) }
+  end
+
+  describe '#error' do
+    subject(:logger) { described_class.new }
+
+    it { expect(logger).to respond_to(:error) }
+  end
+
+  describe '#fatal' do
+    subject(:logger) { described_class.new }
+
+    it { expect(logger).to respond_to(:fatal) }
+  end
+
+  describe '#unknown' do
+    subject(:logger) { described_class.new }
+
+    it { expect(logger).to respond_to(:unknown) }
+  end
+end

--- a/spec/f_http_client/logger/rails_spec.rb
+++ b/spec/f_http_client/logger/rails_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe FHTTPClient::Logger::Rails do
+  describe '#initialize' do
+    context 'when there is no Rails' do
+      it { expect { described_class.new }.to raise_error(NameError, /uninitialized constant Rails/) }
+    end
+
+    context 'when rails is defined' do
+      let(:rails_class) { 'Rails' }
+
+      before { stub_const('Rails', class_double(rails_class, logger: nil)) }
+
+      it { expect(described_class.new).to be_an_instance_of(described_class) }
+    end
+  end
+
+  describe '#tagged' do
+    subject(:logger) { described_class.new }
+
+    let(:rails_class) { 'Rails' }
+
+    before { stub_const('Rails', class_double(rails_class, logger: nil)) }
+
+    it { expect(logger).to respond_to(:tagged) }
+  end
+
+  describe '#debug' do
+    subject(:logger) { described_class.new }
+
+    let(:rails_class) { 'Rails' }
+
+    before { stub_const('Rails', class_double(rails_class, logger: nil)) }
+
+    it { expect(logger).to respond_to(:debug) }
+  end
+
+  describe '#info' do
+    subject(:logger) { described_class.new }
+
+    let(:rails_class) { 'Rails' }
+
+    before { stub_const('Rails', class_double(rails_class, logger: nil)) }
+
+    it { expect(logger).to respond_to(:info) }
+  end
+
+  describe '#warn' do
+    subject(:logger) { described_class.new }
+
+    let(:rails_class) { 'Rails' }
+
+    before { stub_const('Rails', class_double(rails_class, logger: nil)) }
+
+    it { expect(logger).to respond_to(:warn) }
+  end
+
+  describe '#error' do
+    subject(:logger) { described_class.new }
+
+    let(:rails_class) { 'Rails' }
+
+    before { stub_const('Rails', class_double(rails_class, logger: nil)) }
+
+    it { expect(logger).to respond_to(:error) }
+  end
+
+  describe '#fatal' do
+    subject(:logger) { described_class.new }
+
+    let(:rails_class) { 'Rails' }
+
+    before { stub_const('Rails', class_double(rails_class, logger: nil)) }
+
+    it { expect(logger).to respond_to(:fatal) }
+  end
+
+  describe '#unknown' do
+    subject(:logger) { described_class.new }
+
+    let(:rails_class) { 'Rails' }
+
+    before { stub_const('Rails', class_double(rails_class, logger: nil)) }
+
+    it { expect(logger).to respond_to(:unknown) }
+  end
+end


### PR DESCRIPTION
This PR introducess Logging classes to allow the gem to logging information;

- Default logger: Allow to logging using a basic ruby logger;
- Null logger: does not log anything;
- Rails logger: Log using Rails framework logger.