### PR TITLE
Add Helper to simulate an response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Add Response and Exception processors;
 - Add Base client class;
 - Add Basic configuration;
+- Add RSpec helpers to simulate responses

--- a/README.md
+++ b/README.md
@@ -35,14 +35,9 @@ BlogClient::Configuration.configure do |config|
   config.base_uri = 'https://jsonplaceholder.typicode.com'
   confg.log_strategy = :rails
 
-  config.cache do |cache_config|
-    cache_config.strategy :rails
-    cache_config.expires_in 25.minutes
-  end
-
-  congfig.paginate do |pagination_config|
-    pagination_config.per_page = 50
-  end
+  config.cache.strategy = :rails
+  config.cache.expires_in = 25.minutes
+  config.paginate.per_page = 50
 end
 
 

--- a/lib/f_http_client/rspec.rb
+++ b/lib/f_http_client/rspec.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'rspec/support'

--- a/lib/f_http_client/rspec/support.rb
+++ b/lib/f_http_client/rspec/support.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'support/helpers'

--- a/lib/f_http_client/rspec/support/helpers.rb
+++ b/lib/f_http_client/rspec/support/helpers.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'helpers/fake_response'

--- a/lib/f_http_client/rspec/support/helpers/fake_response.rb
+++ b/lib/f_http_client/rspec/support/helpers/fake_response.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FHTTPClientFakeResponse
+  def build_httparty_response(code: 200, parsed_response: {})
+    request_object = HTTParty::Request.new Net::HTTP::Get, '/'
+    response_object = Net::HTTPResponse::CODE_TO_OBJ[code.to_s].new('1.1', code, '')
+    allow(response_object).to receive(:body)
+
+    HTTParty::Response.new(request_object, response_object, -> { parsed_response })
+  end
+end
+
+RSpec.configure do |config|
+  config.include FHTTPClientFakeResponse
+end

--- a/lib/f_http_client/rspec/support/support.rb
+++ b/lib/f_http_client/rspec/support/support.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'support/helpers'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 require 'bundler/setup'
 require 'webmock/rspec'
 require 'f_service/rspec'
+require 'f_http_client/rspec'
 
 require 'f_http_client'
 


### PR DESCRIPTION
This PR introduces a Spec helper to help us to build HTTParty responses to our services:

Ex:

```rb
httparty_response = build_httparty_response(parsed_response: { name: 'Bruno' })
mock_service(Blog::User::Find, result: :success, types: [:ok, :successful], value: httparty_response)
```