### PR TITLE
Add FService as a Runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add FService as runtime dependency.
+
 ## [0.1.0] - 2023-02-13
 
 - Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'f_service', github: 'Fretadao/f_service', branch: 'master'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/Fretadao/f_service.git
-  revision: 22d3e1c8bd4aa83b14f34b1af19aa4cd22b8ad8b
-  branch: master
-  specs:
-    f_service (0.2.0)
-
 PATH
   remote: .
   specs:
@@ -13,6 +6,7 @@ PATH
       addressable
       dry-configurable
       dry-initializer
+      f_service (>= 0.3.0)
       httparty
 
 GEM
@@ -39,6 +33,7 @@ GEM
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     dry-initializer (3.1.1)
+    f_service (0.3.0)
     hashdiff (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
@@ -117,7 +112,6 @@ PLATFORMS
 
 DEPENDENCIES
   f_http_client!
-  f_service!
   pry
   pry-nav
   rake (~> 13.0)

--- a/f_http_client.gemspec
+++ b/f_http_client.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'addressable'
   spec.add_runtime_dependency 'dry-configurable'
   spec.add_runtime_dependency 'dry-initializer'
+  spec.add_runtime_dependency 'f_service', '>= 0.3.0'
   spec.add_runtime_dependency 'httparty'
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
## Tipo de alteração

Este MR implementa as seguintes alterações:

- :heavy_check_mark: **Dívida técnica**.

## Detalhes da solução

Adiciona o FService como uma dependência de runtime.

## Contexto Adicional

A gem FService é uma gem necessária apra que a FHTTPClient funcione.
A gente gerou uma versão com as mais novas funcionalidades da FService no rubygems.
Então, agora é possível gerar essa dependência.

# Checklist

- [X] Testes para novos comportamentos inseridos.
- [X] Atualização do Changelog.
- [ ] Nova versão.
