### PR TITLE
Add SocketError exception rescue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add rescue to SocketError exception;
+
 ## [0.2.0] - 2023-05-22
 
 - Add FService as runtime dependency.

--- a/lib/f_http_client/processor/exception.rb
+++ b/lib/f_http_client/processor/exception.rb
@@ -29,6 +29,8 @@ module FHTTPClient
         case error.class.to_s
         when 'Errno::ECONNREFUSED'
           :connection_refused
+        when 'SocketError'
+          :connection_error
         when /timeout/i
           :timeout
         else

--- a/spec/f_http_client/processor/exception_spec.rb
+++ b/spec/f_http_client/processor/exception_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe FHTTPClient::Processor::Exception do
       end
 
       context 'when the connection could not happen' do
-        let(:error) { SocketError.new('Failed to open TCP connection to fretadao-web:3000 (getaddrinfo: Temporary failure in name resolution)') }
+        let(:error) { SocketError.new('Failed to open TCP connection to...') }
 
         it 'logs the request' do
           exception_processor

--- a/spec/f_http_client/processor/exception_spec.rb
+++ b/spec/f_http_client/processor/exception_spec.rb
@@ -70,6 +70,19 @@ RSpec.describe FHTTPClient::Processor::Exception do
         end
       end
 
+      context 'when the connection could not happen' do
+        let(:error) { SocketError.new('Failed to open TCP connection to fretadao-web:3000 (getaddrinfo: Temporary failure in name resolution)') }
+
+        it 'logs the request' do
+          exception_processor
+          expect(FHTTPClient::Log).to have_received(:call)
+        end
+
+        it 'fails with connection refused error' do
+          expect(exception_processor).to have_failed_with(:connection_error, :exception).and_error(error)
+        end
+      end
+
       context 'when the connection gets a timeout' do
         let(:error) { Net::ReadTimeout.new('a timeout happened') }
 


### PR DESCRIPTION
## Tipo de alteração

Este MR implementa as seguintes alterações:

- :heavy_check_mark: **Dívida técnica**.

## Detalhes da solução

Add SocketError exception rescue

## Contexto Adicional

This exception happens when the other system is down. It's similar to Errno::ECONNREFUSED,

# Checklist

- [X] Testes para novos comportamentos inseridos.
- [X] Atualização do Changelog.
- [ ] Nova versão.
