### PR TITLE
Disable Gemspec/RequireMFA cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,3 +119,7 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/NestedGroups:
   Enabled: false
+
+##### RUBYGEMS #####
+Gemspec/RequireMFA:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Change Disable rubygems MFA checking #14
+
 ## [0.2.1] - 2023-09-27
 
 - Add rescue to SocketError exception. #12


### PR DESCRIPTION
## Tipo de alteração

Este MR implementa as seguintes alterações:

- :heavy_check_mark: **Dívida técnica**

## Detalhes da solução

Disable the cop which warns when we disable MFA to publish a gem on rubygems.
Wich was disabled here: https://github.com/Fretadao/f_http_client/commit/a0460ff0a514164013663a716e46c3c0dfe1635b

# Checklist

- [X] Testes para novos comportamentos inseridos.
- [x] Atualização do Changelog.
- [ ] Nova versão.
