### PR TITLE
feat!: expose RFC 9110 status type aliases for 422 and 413 [CU-86ak35ptc]

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,42 @@ Result examples:
 ```rb
 Person::Create.(name: 'Joe Vicenzo', birthdate: '2000-01-01')
   .and_then { |user| return redirect_to users_path(user.id) }
-  .on_failure(:unprocessable_entity) { |errors| return render_action :new, locals: { errors: errors } }
+  .on_failure(:unprocessable_content) { |errors| return render_action :new, locals: { errors: errors } }
   .on_failure(:client_error) { |errors| render_action :new, warning: errors }
   .on_failure(:server_error) { |error| render_action :new, warning: ['Try again latter.'] }
   .on_failure(:server_error) { |error| render_action :new, warning: ['Server is busy. Try again latter.'] }
   .on_failure { |_error, type| render_action :new, warning: ["Unexpected error. Contact admin and talk about #{type} error."] }
+```
+
+### Status names renamed by RFC 9110
+
+The failure/success type comes from the `Net::HTTPResponse` class name, which still carries the
+pre-RFC 9110 names for two status codes. Rack 3.1+ — and therefore every Rails app — already
+canonicalized them. For those two codes the result carries **both** symbols as types, canonical
+first, so either name matches:
+
+| Status | Canonical type (Rack 3.1+) | Legacy type (still matches) |
+|--------|----------------------------|-----------------------------|
+| 422    | `:unprocessable_content`   | `:unprocessable_entity`     |
+| 413    | `:content_too_large`       | `:payload_too_large`        |
+
+```rb
+# A 422 response yields the types below, in this order:
+# [:unprocessable_content, :unprocessable_entity, :client_error]
+
+Person::Create.(name: 'Joe Vicenzo')
+  .on_failure(:unprocessable_content) { |errors| render_action :new, locals: { errors: errors } }
+  .on_failure(:unprocessable_entity) { |errors| render_action :new, locals: { errors: errors } }
+```
+
+Prefer the canonical name: an untyped `on_failure` receives it as the `type`, and the legacy one is
+kept only to ease the migration — it will be dropped in a future major release.
+
+If you assert on types with the FService matchers, note that `have_failed_with` compares the whole
+type list, so specs covering those two codes need the full trio:
+
+```rb
+expect(result).to have_failed_with(:unprocessable_content, :unprocessable_entity, :client_error)
 ```
 
 This gem uses the gem [HTTParty](https://github.com/jnunemaker/httparty) as base to perform requests.

--- a/lib/f_http_client/processor/response.rb
+++ b/lib/f_http_client/processor/response.rb
@@ -34,6 +34,24 @@ module FHTTPClient
 
       private_constant :STATUS_FAMILIES
 
+      # Status codes whose canonical name changed with RFC 9110. The type comes from
+      # Net::HTTPResponse::CODE_TO_OBJ, which still carries the pre-RFC names, while Rack
+      # 3.1+ (and therefore every Rails app consuming this gem) already canonicalized them.
+      # Emitting both symbols, canonical first, lets `on_failure` match either name so
+      # consumers can migrate at their own pace.
+      #
+      # TODO: Drop this constant and #response_types once net-http adopts the RFC 9110 names
+      # (or the status-to-type source stops being CODE_TO_OBJ) AND consumers have migrated
+      # off the legacy names. See Rack::Utils OBSOLETE_SYMBOL_MAPPINGS (rack >= 3.1).
+      RENAMED_TYPES = {
+        unprocessable_entity: %i[unprocessable_content unprocessable_entity],
+        unprocessable_content: %i[unprocessable_content unprocessable_entity],
+        payload_too_large: %i[content_too_large payload_too_large],
+        content_too_large: %i[content_too_large payload_too_large]
+      }.freeze
+
+      private_constant :RENAMED_TYPES
+
       def run
         log_data.and_then { success? ? success_response : failure_response }
       end
@@ -43,11 +61,24 @@ module FHTTPClient
       def_delegators :@response, :headers, :success?, :parsed_response, :code
 
       def success_response
-        Success(response_type, response_family, data: response)
+        Success(*response_types, response_family, data: response)
       end
 
       def failure_response
-        Failure(response_type, response_family, data: response)
+        Failure(*response_types, response_family, data: response)
+      end
+
+      # Private:
+      # Result types for the response status, from the canonical name to the legacy one.
+      # Ex: When the request returns a 422 (Unprocessable Content)
+      #
+      # # => [:unprocessable_content, :unprocessable_entity]
+      #
+      # Ex: When the request returns a 404 (Not Found)
+      #
+      # # => [:not_found]
+      def response_types
+        RENAMED_TYPES.fetch(response_type) { [response_type] }
       end
 
       # Private:

--- a/spec/f_http_client/processor/response_spec.rb
+++ b/spec/f_http_client/processor/response_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe FHTTPClient::Processor::Response do
           expect(FHTTPClient::Log).to have_received(:call)
         end
 
-        it 'returns a Fservice failure', :aggregate_failures do
-          processed_response = response_processor
-          expect(processed_response).to have_failed_with(:continue, :informational)
-          expect(processed_response.error).to be_an_instance_of(HTTParty::Response)
+        it 'returns a Fservice failure' do
+          expect(response_processor)
+            .to have_failed_with(:continue, :informational)
+            .and_error(be_an_instance_of(HTTParty::Response))
         end
       end
 
@@ -98,10 +98,10 @@ RSpec.describe FHTTPClient::Processor::Response do
           expect(FHTTPClient::Log).to have_received(:call)
         end
 
-        it 'returns a Fservice success', :aggregate_failures do
-          processed_response = response_processor
-          expect(processed_response).to have_succeed_with(:created, :successful)
-          expect(processed_response.value).to be_an_instance_of(HTTParty::Response)
+        it 'returns a Fservice success' do
+          expect(response_processor)
+            .to have_succeed_with(:created, :successful)
+            .and_value(be_an_instance_of(HTTParty::Response))
         end
       end
 
@@ -114,10 +114,10 @@ RSpec.describe FHTTPClient::Processor::Response do
           expect(FHTTPClient::Log).to have_received(:call)
         end
 
-        it 'returns a Fservice failure', :aggregate_failures do
-          processed_response = response_processor
-          expect(processed_response).to have_failed_with(:not_found, :client_error)
-          expect(processed_response.error).to be_an_instance_of(HTTParty::Response)
+        it 'returns a Fservice failure' do
+          expect(response_processor)
+            .to have_failed_with(:not_found, :client_error)
+            .and_error(be_an_instance_of(HTTParty::Response))
         end
       end
 
@@ -130,10 +130,57 @@ RSpec.describe FHTTPClient::Processor::Response do
           expect(FHTTPClient::Log).to have_received(:call)
         end
 
-        it 'returns a Fservice failure', :aggregate_failures do
-          processed_response = response_processor
-          expect(processed_response).to have_failed_with(:bad_gateway, :server_error)
-          expect(processed_response.error).to be_an_instance_of(HTTParty::Response)
+        it 'returns a Fservice failure' do
+          expect(response_processor)
+            .to have_failed_with(:bad_gateway, :server_error)
+            .and_error(be_an_instance_of(HTTParty::Response))
+        end
+      end
+
+      context 'when the http response is an unprocessable content' do
+        let(:code) { 422 }
+        let(:body) { { errors: { name: ["can't be blank"] } } }
+
+        it 'returns a Fservice failure carrying both the canonical and the legacy type' do
+          expect(response_processor)
+            .to have_failed_with(:unprocessable_content, :unprocessable_entity, :client_error)
+            .and_error(be_an_instance_of(HTTParty::Response))
+        end
+
+        it 'matches on_failure by the canonical type' do
+          expect { |handler| response_processor.on_failure(:unprocessable_content, &handler) }
+            .to yield_control
+        end
+
+        it 'matches on_failure by the legacy type' do
+          expect { |handler| response_processor.on_failure(:unprocessable_entity, &handler) }
+            .to yield_control
+        end
+
+        it 'yields the canonical type to an untyped on_failure' do
+          expect { |handler| response_processor.on_failure(&handler) }
+            .to yield_with_args(an_instance_of(HTTParty::Response), :unprocessable_content)
+        end
+      end
+
+      context 'when the http response is a content too large' do
+        let(:code) { 413 }
+        let(:body) { { errors: { file: ['is too big'] } } }
+
+        it 'returns a Fservice failure carrying both the canonical and the legacy type' do
+          expect(response_processor)
+            .to have_failed_with(:content_too_large, :payload_too_large, :client_error)
+            .and_error(be_an_instance_of(HTTParty::Response))
+        end
+
+        it 'matches on_failure by the canonical type' do
+          expect { |handler| response_processor.on_failure(:content_too_large, &handler) }
+            .to yield_control
+        end
+
+        it 'matches on_failure by the legacy type' do
+          expect { |handler| response_processor.on_failure(:payload_too_large, &handler) }
+            .to yield_control
         end
       end
 
@@ -146,10 +193,10 @@ RSpec.describe FHTTPClient::Processor::Response do
           expect(FHTTPClient::Log).to have_received(:call)
         end
 
-        it 'returns a Fservice failure', :aggregate_failures do
-          processed_response = response_processor
-          expect(processed_response).to have_failed_with(:unknown_type, :unknown_family)
-          expect(processed_response.error).to be_an_instance_of(HTTParty::Response)
+        it 'returns a Fservice failure' do
+          expect(response_processor)
+            .to have_failed_with(:unknown_type, :unknown_family)
+            .and_error(be_an_instance_of(HTTParty::Response))
         end
       end
     end


### PR DESCRIPTION
## What changed

The result type is derived from `Net::HTTPResponse::CODE_TO_OBJ`, which still carries the
pre-RFC 9110 names for two status codes. Rack 3.1+ — and therefore every Rails app consuming
this gem — already canonicalized them, and `rubocop-rails` 2.34 enforces the new names through
`Rails/HttpStatusNameConsistency`. The apps migrated, the gem did not, so consumers were stuck
writing `:unprocessable_entity` in `on_failure` hooks while the rest of their code said
`:unprocessable_content`.

| Status | Was (via net-http) | Canonical (Rack 3.1+) |
|--------|--------------------|-----------------------|
| 422    | `:unprocessable_entity` | `:unprocessable_content` |
| 413    | `:payload_too_large`    | `:content_too_large`     |

For those two codes the result now carries **both** symbols as types, canonical first:

```rb
# a 422 response
result.types # => [:unprocessable_content, :unprocessable_entity, :client_error]

result.on_failure(:unprocessable_content) { }        # matches
result.on_failure(:unprocessable_entity) { }         # still matches
result.on_failure { |_response, type| type }         # => :unprocessable_content
```

The translation lives in a private `RENAMED_TYPES` map keyed in both directions, so it keeps
working — and keeps the same canonical-first order — if net-http renames the classes later. It
carries a `TODO` to be dropped once net-http adopts the RFC 9110 names *and* consumers have
migrated off the legacy ones. `response_type`, `response_family`, `message` and `response_class`
are untouched.

`414` and `416` needed nothing: net-http already reports `:uri_too_long` and
`:range_not_satisfiable`, matching Rack.

Card: [CU-86ak35ptc](https://app.clickup.com/t/86ak35ptc)

## Type of change

- [x] `feat` — new capability *(triggers a minor release)*
- [x] breaking change — `!` in the title or a `BREAKING CHANGE:` footer

## Behaviour before and after

**Runtime is backwards compatible.** `on_failure` matches by inclusion (`types.include?`), so
every existing hook keeps firing. What changes is that an untyped `on_failure` now yields
`:unprocessable_content` instead of `:unprocessable_entity` as the `type`.

**Specs are not.** The FService matchers compare the type list for equality, so a consuming spec
asserting the exact list fails once a third type shows up:

```rb
# before
expect(result).to have_failed_with(:unprocessable_entity, :client_error)

# after
expect(result).to have_failed_with(:unprocessable_content, :unprocessable_entity, :client_error)
```

Seven specs in the monorepo need that adjustment when the gem is bumped, all under classes
inheriting from `FHTTPClient::Base` through `WebApi::Base`:

- `apps/router/spec/lib/web_api/business_parameter/synchronize_spec.rb`
- `apps/router/spec/lib/web_api/extra_route/create_spec.rb`
- `apps/router/spec/lib/web_api/extra_route/update_spec.rb`
- `apps/router/spec/lib/web_api/line/update_spec.rb`
- `apps/router/spec/lib/web_api/occasional_trip_request/create_spec.rb`
- `apps/router/spec/lib/web_api/occasional_trip_request/update_spec.rb`
- `apps/web/spec/lib/router_api/occasional_trip_request/prospection/create_spec.rb`

Their production code needs no change. The `have_failed_with(:unprocessable_entity)` assertions
in `libs/uber-client/spec/**` are **not** affected — that gem does not depend on this one.

## Additional context

- [Rack 3.1 `OBSOLETE_SYMBOL_MAPPINGS`](https://github.com/rack/rack/blob/main/lib/rack/utils.rb) —
  the two codes handled here are exactly the two entries in that map.
- RFC 9110 renamed 422 to *Unprocessable Content* and 413 to *Content Too Large*; net-http's
  `responses.rb` already cites the RFC in a comment but has not renamed the classes.

Specs for 422 and 413 did not exist before this PR (the file covered 100, 201, 404, 502 and 99),
so a future rename in net-http would have passed silently. They exist now. The pre-existing
contexts were also converted to the chained matcher style (`.and_error` / `.and_value`), dropping
the `:aggregate_failures` and the intermediate variables.

## TO-DO

Bump the gem in `apps/router` and `apps/web` and apply the seven spec adjustments listed above —
worth a separate card, since this gem releases independently.

## Checklist

- [ ] The **PR title** is a valid Conventional Commit (`type: short description`).
      This PR is squash-merged, so the title is the commit release-please reads to
      decide the next version and to write the `CHANGELOG.md`.
- [ ] `bundle exec rubocop -c .rubocop.yml --parallel` and `bundle exec rspec` pass
      locally.
- [ ] New behaviour ships with specs.
- [ ] The `CHANGELOG.md` was **not** edited by hand and the version was **not**
      bumped; release-please owns both.
- [ ] A breaking change is flagged with `!` or a `BREAKING CHANGE:` footer, and says
      what consumers should use instead.
